### PR TITLE
Migrate README to markdown

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,0 @@
-This overlay contains only packages migrated to generation 2 (java-*-2 eclass
-using ebuilds). Ebuilds in this overlay are expected to work so report bugs to
-gentoo-java@lists.gentoo.org or our #gentoo-java IRC channel in Freenode.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Gentoo java overlay
+
+This overlay contains only packages migrated to generation 2 (java-*-2 eclass
+using ebuilds). Ebuilds in this overlay are expected to work.
+
+The overlay is hosted on Github and on the official Gentoo Overlays
+infrastructure at:
+
+- https://github.com/gentoo/java-overlay
+- https://gitweb.gentoo.org/proj/java.git
+
+If you have questions, you can find us on IRC in #gentoo-java on Freenode or at
+[java@gentoo.org](mailto:java@gentoo.org).
+
+Bugs should be reported on https://bugs.gentoo.org. Be sure to include
+"[java-overlay]" in the summary of your bug report. If you prefer mailing lists
+please use [gentoo-java@lists.gentoo.org](mailto:gentoo-java@lists.gentoo.org).


### PR DESCRIPTION
Inspired by kde overlay:
- Moves README to popular markdown format
- Updates the content a little bit