### PR TITLE
Travis ci support with irc notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+#
+# Run repoman via travis
+# See https://github.com/mrueg/repoman-travis
+#
+language: python
+python:
+    - pypy
+env:
+    - PORTAGE_VER="2.2.20"
+before_script:
+    - mkdir travis-overlay
+    - mv !(travis-overlay) travis-overlay/
+    - mv .git travis-overlay/
+    - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/.travis.yml" -O .travis.yml.upstream
+    - wget "https://github.com/gentoo/portage/archive/v${PORTAGE_VER}.tar.gz" -O portage-${PORTAGE_VER}.tar.gz
+    - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/spinner.sh"
+    - wget "https://github.com/gentoo/gentoo-portage-rsync-mirror/archive/master.tar.gz" -O portage-tree.tar.gz
+    - sudo chmod a+rwX /etc/passwd /etc/group /etc /usr spinner.sh
+    - chmod a+rwx spinner.sh
+    - echo "portage:x:250:250:portage:/var/tmp/portage:/bin/false" >> /etc/passwd
+    - echo "portage::250:portage,travis" >> /etc/group
+    - mkdir -p /etc/portage/ /usr/portage/distfiles
+    - tar xzf portage-${PORTAGE_VER}.tar.gz
+    - tar xzf portage-tree.tar.gz -C /usr/portage --strip-components=1
+    - cp portage-${PORTAGE_VER}/cnf/repos.conf /etc/portage/
+    - ln -s /usr/portage/profiles/base/ /etc/portage/make.profile
+    - wget "https://www.gentoo.org/dtd/metadata.dtd" -O /usr/portage/distfiles/metadata.dtd
+    - SIZE=`stat -c %s .travis.yml.upstream`
+    - if ! cmp -n $SIZE -s .travis.yml .travis.yml.upstream; then  echo -e "\e[31m !!! .travis.yml outdated! Update available https://github.com/mrueg/repoman-travis \e[0m" > /tmp/update ; fi
+    - cd travis-overlay
+script:
+    - ./../spinner.sh "./../portage-${PORTAGE_VER}/bin/repoman full -d"
+# You can append own scripts after this line
+notifications:
+  irc:
+    channels:
+      - "chat.freenode.net#gentoo-java"
+    template:
+      - "%{repository}#%{build_number} (%{branch} - %{commit}): %{message}"
+      - "%{author} - %{commit_message}"
+      - "Change view : %{compare_url}"
+      - "Build details : %{build_url}"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Gentoo java overlay
 
+[![Repoman Status](https://travis-ci.org/gentoo/java-overlay.png)](https://travis-ci.org/gentoo/java-overlay)
+
 This overlay contains only packages migrated to generation 2 (java-*-2 eclass
 using ebuilds). Ebuilds in this overlay are expected to work.
 


### PR DESCRIPTION
Travis continues integration based on repoman qa checks. CI results promoted to
irc channel #gentoo-java @ freenode.